### PR TITLE
Request to Merge

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroClass.java
@@ -250,18 +250,11 @@ public final class MacroClass {
       parsedVisibility = RuleVisibility.parse(liftedVisibility);
     }
     // Concatenate the visibility (as previously populated) with the instantiation site's location.
-    PackageIdentifier instantiatingLoc;
-    if (parentMacroFrame == null) {
-      instantiatingLoc = pkgBuilder.getPackageIdentifier();
-    } else {
-      instantiatingLoc =
-          parentMacroFrame
-              .macroInstance
-              .getMacroClass()
-              .getDefiningBzlLabel()
-              .getPackageIdentifier();
-    }
-    parsedVisibility = RuleVisibility.concatWithPackage(parsedVisibility, instantiatingLoc);
+    PackageIdentifier instantiatingLoc =
+        parentMacroFrame == null
+            ? pkgBuilder.getPackageIdentifier()
+            : parentMacroFrame.macroInstance.getDefinitionPackage();
+    parsedVisibility = parsedVisibility.concatWithPackage(instantiatingLoc);
     attrValues.put("visibility", parsedVisibility.getDeclaredLabels());
 
     // Populate defaults for the rest, and validate that no mandatory attr was missed.

--- a/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java
@@ -181,21 +181,14 @@ public final class MacroInstance {
   }
 
   /**
-   * Returns a {@code RuleVisibility} representing the result of concatenating this macro's {@link
-   * MacroClass}'s definition location to the given {@code visibility}.
+   * Returns the package containing the .bzl file from which this macro instance's macro class was
+   * exported.
    *
-   * <p>The definition location of a macro class is the package containing the .bzl file from which
-   * the macro class was exported.
-   *
-   * <p>Logically, this represents the visibility that a target would have, if it were passed the
-   * given value for its {@code visibility} attribute, and if the target were declared directly in
-   * this macro (i.e. not in a submacro).
+   * <p>This is considered to be the place where the macro's code lives, and is used as the place
+   * where a target is instantiated for the purposes of Macro-Aware Visibility.
    */
-  // TODO: #19922 - Maybe refactor this to getDefinitionLocation and let the caller do the concat,
-  // so we don't have to basically repeat it in MacroClass#instantiateMacro.
-  public RuleVisibility concatDefinitionLocationToVisibility(RuleVisibility visibility) {
-    PackageIdentifier macroLocation = macroClass.getDefiningBzlLabel().getPackageIdentifier();
-    return RuleVisibility.concatWithPackage(visibility, macroLocation);
+  public PackageIdentifier getDefinitionPackage() {
+    return macroClass.getDefiningBzlLabel().getPackageIdentifier();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/PackageGroupsRuleVisibility.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/PackageGroupsRuleVisibility.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 /** A rule visibility that allows visibility to a list of package groups. */
 @AutoValue
-public abstract class PackageGroupsRuleVisibility implements RuleVisibility {
+public abstract class PackageGroupsRuleVisibility extends RuleVisibility {
   public abstract ImmutableList<Label> getPackageGroups();
 
   public abstract PackageGroupContents getDirectPackages();

--- a/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java
@@ -311,7 +311,7 @@ public class RuleFactory {
       }
     }
 
-    return currentMacro.concatDefinitionLocationToVisibility(visibility).getDeclaredLabels();
+    return visibility.concatWithPackage(currentMacro.getDefinitionPackage()).getDeclaredLabels();
   }
 
   /**

--- a/src/main/java/com/google/devtools/build/lib/packages/StarlarkNativeModule.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/StarlarkNativeModule.java
@@ -556,7 +556,7 @@ public class StarlarkNativeModule implements StarlarkNativeModuleApi {
                     visibilityO, "'exports_files' operand", pkgBuilder.getLabelConverter()));
     MacroInstance currentMacro = pkgBuilder.currentMacro();
     if (currentMacro != null) {
-      visibility = currentMacro.concatDefinitionLocationToVisibility(visibility);
+      visibility = visibility.concatWithPackage(currentMacro.getDefinitionPackage());
     }
 
     // TODO(bazel-team): is licenses plural or singular?


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
enhancement, tests


___

### **Description**
- Refactored the `RuleVisibility` class from an interface to an abstract class, adding `equals` and `hashCode` methods for better comparison and hashing.
- Simplified visibility concatenation logic across multiple classes by introducing and using the `concatWithPackage` method.
- Updated test cases in `RuleVisibilityTest` to reflect changes in visibility logic and removed redundant methods.
- Implemented `getDefinitionPackage` in `MacroInstance` to streamline package retrieval.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MacroClass.java</strong><dd><code>Refactor visibility concatenation logic in MacroClass</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/google/devtools/build/lib/packages/MacroClass.java

<li>Refactored visibility concatenation logic.<br> <li> Simplified conditional logic using ternary operator.<br> <li> Updated method calls to use new <code>concatWithPackage</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/1/files#diff-251d0c566865ce86c6b0321d1d3e27024835d35e82c2367bde0794845982de94">+5/-12</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>MacroInstance.java</strong><dd><code>Implement getDefinitionPackage method in MacroInstance</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/google/devtools/build/lib/packages/MacroInstance.java

<li>Implemented <code>getDefinitionPackage</code> method.<br> <li> Removed old concatenation logic.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/1/files#diff-7d6944fc26c59f67a8ad5a9a5bc4c06aabc3c9f92686a13f3da7b829c6bad491">+6/-13</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>PackageGroupsRuleVisibility.java</strong><dd><code>Change PackageGroupsRuleVisibility to extend RuleVisibility</code></dd></summary>
<hr>

src/main/java/com/google/devtools/build/lib/packages/PackageGroupsRuleVisibility.java

<li>Changed class from implementing interface to extending abstract class.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/1/files#diff-7a84c1c601a8c833daf80cceb498bded713835c423cd73932b6ebacb663c3f1d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RuleFactory.java</strong><dd><code>Update visibility modification logic in RuleFactory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/google/devtools/build/lib/packages/RuleFactory.java

- Updated visibility modification logic to use `concatWithPackage`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/1/files#diff-c1bfae26af486cde8d6ed481e822fd833d84dce24d95685970495e0b75bc9f16">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>RuleVisibility.java</strong><dd><code>Refactor RuleVisibility and add utility methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/google/devtools/build/lib/packages/RuleVisibility.java

<li>Refactored RuleVisibility from interface to abstract class.<br> <li> Added <code>equals</code> and <code>hashCode</code> methods.<br> <li> Renamed <code>validate</code> method to <code>checkForVisibilityMisspelling</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/1/files#diff-3e7c94dcd47ef9003f9c07866220eb936b4c593661dd668649daa404fcd9d6a3">+61/-53</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StarlarkNativeModule.java</strong><dd><code>Update visibility logic in StarlarkNativeModule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/google/devtools/build/lib/packages/StarlarkNativeModule.java

- Updated visibility logic to use `concatWithPackage`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/1/files#diff-6540ec6a271e9b89656af3d9ab3e3d8ef65bafa7afe6a7d218c6cdf37bbaab65">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RuleVisibilityTest.java</strong><dd><code>Update RuleVisibility tests for new logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/test/java/com/google/devtools/build/lib/packages/RuleVisibilityTest.java

<li>Added <code>pkg</code> helper method for tests.<br> <li> Updated test cases to reflect new visibility logic.<br> <li> Removed redundant <code>assertEqual</code> method.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/1/files#diff-65121d1cd45e2187161cdead31668a18cd7e45c2641d4066c966096be0e39e48">+19/-25</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information