### PR TITLE
Request to Merge

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/skyframe/serialization/SkyValueRetriever.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/serialization/SkyValueRetriever.java
@@ -20,6 +20,7 @@ import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 import com.google.common.hash.HashCode;
 import com.google.common.primitives.Bytes;
 import com.google.common.util.concurrent.Futures;
@@ -328,8 +329,7 @@ public final class SkyValueRetriever {
   /** A tuple representing the version of a cached SkyValue in the frontier. */
   public static final class FrontierNodeVersion {
     public static final FrontierNodeVersion CONSTANT_FOR_TESTING =
-        new FrontierNodeVersion(
-            "123", ByteString.copyFrom(new byte[] {1, 2, 3}), HashCode.fromInt(42));
+        new FrontierNodeVersion("123", "string_for_testing", HashCode.fromInt(42));
     private final byte[] topLevelConfigFingerprint;
     private final byte[] directoryMatcherFingerprint;
     private final byte[] blazeInstallMD5Fingerprint;
@@ -337,11 +337,11 @@ public final class SkyValueRetriever {
 
     public FrontierNodeVersion(
         String topLevelConfigChecksum,
-        ByteString directoryMatcherFingerprint,
+        String directoryMatcherStringRepr,
         HashCode blazeInstallMD5) {
       // TODO: b/364831651 - add more fields like source and blaze versions.
       this.topLevelConfigFingerprint = topLevelConfigChecksum.getBytes(UTF_8);
-      this.directoryMatcherFingerprint = directoryMatcherFingerprint.toByteArray();
+      this.directoryMatcherFingerprint = directoryMatcherStringRepr.getBytes(UTF_8);
       this.blazeInstallMD5Fingerprint = blazeInstallMD5.asBytes();
       this.precomputedFingerprint =
           Bytes.concat(
@@ -356,6 +356,16 @@ public final class SkyValueRetriever {
 
     public byte[] concat(byte[] input) {
       return Bytes.concat(precomputedFingerprint, input);
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("topLevelConfig", Arrays.hashCode(topLevelConfigFingerprint))
+          .add("directoryMatcher", Arrays.hashCode(directoryMatcherFingerprint))
+          .add("blazeInstall", Arrays.hashCode(blazeInstallMD5Fingerprint))
+          .add("precomputed", hashCode())
+          .toString();
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/skyframe/serialization/SkyValueRetrieverTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/serialization/SkyValueRetrieverTest.java
@@ -167,7 +167,7 @@ public final class SkyValueRetrieverTest implements SerializationStateProvider {
     var version =
         new FrontierNodeVersion(
             /* topLevelConfigChecksum= */ "42",
-            /* directoryMatcherFingerprint= */ ByteString.copyFrom(new byte[] {1, 2, 3}),
+            /* directoryMatcherStringRepr= */ "some_string",
             /* blazeInstallMD5= */ HashCode.fromInt(42));
     uploadKeyValuePair(key, version, value, fingerprintValueService);
 
@@ -194,7 +194,7 @@ public final class SkyValueRetrieverTest implements SerializationStateProvider {
     var version =
         new FrontierNodeVersion(
             /* topLevelConfigChecksum= */ "42",
-            /* directoryMatcherFingerprint= */ ByteString.copyFrom(new byte[] {1, 2, 3}),
+            /* directoryMatcherStringRepr= */ "some_string",
             /* blazeInstallMD5= */ HashCode.fromInt(42));
     uploadKeyValuePair(key, version, value, fingerprintValueService);
 
@@ -208,7 +208,7 @@ public final class SkyValueRetrieverTest implements SerializationStateProvider {
             /* stateProvider= */ this,
             /* frontierNodeVersion= */ new FrontierNodeVersion(
                 /* topLevelConfigChecksum= */ "9000",
-                /* directoryMatcherFingerprint= */ ByteString.copyFrom(new byte[] {7, 8, 9}),
+                /* directoryMatcherStringRepr= */ "another_string",
                 /* blazeInstallMD5= */ HashCode.fromInt(9000)));
 
     assertThat(result).isSameInstanceAs(NO_CACHED_DATA);
@@ -546,10 +546,8 @@ public final class SkyValueRetrieverTest implements SerializationStateProvider {
 
   @Test
   public void frontierNodeVersions_areEqual_ifTupleComponentsAreEqual() {
-    var first =
-        new FrontierNodeVersion("foo", ByteString.copyFromUtf8("bar"), HashCode.fromInt(42));
-    var second =
-        new FrontierNodeVersion("foo", ByteString.copyFromUtf8("bar"), HashCode.fromInt(42));
+    var first = new FrontierNodeVersion("foo", "bar", HashCode.fromInt(42));
+    var second = new FrontierNodeVersion("foo", "bar", HashCode.fromInt(42));
 
     assertThat(first.getPrecomputedFingerprint()).isEqualTo(second.getPrecomputedFingerprint());
     assertThat(first).isEqualTo(second);
@@ -557,10 +555,8 @@ public final class SkyValueRetrieverTest implements SerializationStateProvider {
 
   @Test
   public void frontierNodeVersions_areNotEqual_ifTopLevelConfigChecksumIsDifferent() {
-    var first =
-        new FrontierNodeVersion("foo", ByteString.copyFromUtf8("bar"), HashCode.fromInt(42));
-    var second =
-        new FrontierNodeVersion("CHANGED", ByteString.copyFromUtf8("bar"), HashCode.fromInt(42));
+    var first = new FrontierNodeVersion("foo", "bar", HashCode.fromInt(42));
+    var second = new FrontierNodeVersion("CHANGED", "bar", HashCode.fromInt(42));
 
     assertThat(first.getPrecomputedFingerprint()).isNotEqualTo(second.getPrecomputedFingerprint());
     assertThat(first).isNotEqualTo(second);
@@ -568,10 +564,8 @@ public final class SkyValueRetrieverTest implements SerializationStateProvider {
 
   @Test
   public void frontierNodeVersions_areNotEqual_ifActiveDirectoriesAreDifferent() {
-    var first =
-        new FrontierNodeVersion("foo", ByteString.copyFromUtf8("bar"), HashCode.fromInt(42));
-    var second =
-        new FrontierNodeVersion("foo", ByteString.copyFromUtf8("CHANGED"), HashCode.fromInt(42));
+    var first = new FrontierNodeVersion("foo", "bar", HashCode.fromInt(42));
+    var second = new FrontierNodeVersion("foo", "CHANGED", HashCode.fromInt(42));
 
     assertThat(first.getPrecomputedFingerprint()).isNotEqualTo(second.getPrecomputedFingerprint());
     assertThat(first).isNotEqualTo(second);
@@ -579,10 +573,8 @@ public final class SkyValueRetrieverTest implements SerializationStateProvider {
 
   @Test
   public void frontierNodeVersions_areNotEqual_ifBlazeInstallMD5IsDifferent() {
-    var first =
-        new FrontierNodeVersion("foo", ByteString.copyFromUtf8("bar"), HashCode.fromInt(42));
-    var second =
-        new FrontierNodeVersion("foo", ByteString.copyFromUtf8("bar"), HashCode.fromInt(9000));
+    var first = new FrontierNodeVersion("foo", "bar", HashCode.fromInt(42));
+    var second = new FrontierNodeVersion("foo", "bar", HashCode.fromInt(9000));
 
     assertThat(first.getPrecomputedFingerprint()).isNotEqualTo(second.getPrecomputedFingerprint());
     assertThat(first).isNotEqualTo(second);


### PR DESCRIPTION
### **User description**
> [!NOTE]
> I'm currently writing a description for your pull request. I should be done shortly (<1 minute). Please don't edit the description field until I'm finished, or we may overwrite each other. If I find nothing to write about, I'll delete this message.


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Implemented double-checked locking in `getSkyValueVersion` to prevent multiple instantiations of `FrontierNodeVersion`.
- Changed `frontierNodeVersionSingleton` to be volatile for thread safety.
- Removed unnecessary serialization of `activeDirectoriesMatcher` to a string representation.
- Added logging for debugging purposes in `getSkyValueVersion`.
- Refactored `FrontierNodeVersion` to use string representations instead of `ByteString`.
- Added a `toString` method to `FrontierNodeVersion` for better logging and debugging.
- Updated unit tests to reflect changes in `FrontierNodeVersion` construction and equality checks.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildTool.java</strong><dd><code>Improve synchronization and logging in BuildTool</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java

<li>Added double-checked locking to <code>getSkyValueVersion</code>.<br> <li> Changed <code>frontierNodeVersionSingleton</code> to be volatile.<br> <li> Removed serialization of <code>activeDirectoriesMatcher</code> to string.<br> <li> Added logging for debugging SkyValue version components.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/3/files#diff-d6c790d314f32d415d39ebd0dc682f1f40defca96d29c30b320cc4f97556525a">+22/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>SkyValueRetriever.java</strong><dd><code>Refactor FrontierNodeVersion to use strings and add toString</code></dd></summary>
<hr>

src/main/java/com/google/devtools/build/lib/skyframe/serialization/SkyValueRetriever.java

<li>Changed <code>FrontierNodeVersion</code> to use strings instead of ByteString.<br> <li> Added <code>toString</code> method for <code>FrontierNodeVersion</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/3/files#diff-7f66cd227210cedc625a86333ef9a5087c3b577473c60d6d428cd26596fe61a7">+14/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SkyValueRetrieverTest.java</strong><dd><code>Update tests for FrontierNodeVersion string representation</code></dd></summary>
<hr>

src/test/java/com/google/devtools/build/lib/skyframe/serialization/SkyValueRetrieverTest.java

<li>Updated tests to use string representation for <code>FrontierNodeVersion</code>.<br> <li> Adjusted test cases for equality checks on <code>FrontierNodeVersion</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/bazel/pull/3/files#diff-65fb08f7f9a2ec743dfb008434ced8333b62e7a8d409e7d09841e371df128e7d">+11/-19</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information